### PR TITLE
use py launcher to select correct python version for venv

### DIFF
--- a/Madmom.pyproj
+++ b/Madmom.pyproj
@@ -39,7 +39,7 @@
     <Compile Include="setup.py" />
   </ItemGroup>
   <Target Name="BeforeBuild" Inputs="$(ProjectDir)\requirements.txt" Outputs="$(ProjectDir)\env\pyvenv.cfg">
-    <Exec Command="python -m venv env &amp; cd env &amp; Scripts\pip install -r ..\requirements.txt" />
+    <Exec Command="py -3.7 -m venv env &amp; cd env &amp; Scripts\pip install -r ..\requirements.txt" />
   </Target>
   <Target Name="CoreCompile" />
   <Target Name="AfterBuild" Inputs="@(Compile)" Outputs="$(ProjectDir)\build\temp.win-amd64-3.7/Release/madmom/features/beats_crf.obj">


### PR DESCRIPTION
## Changes proposed in this pull request

Change pre-build command responsible for creating the python venv to look for Python 3.7 specifically.

This pull request fixes [spectrum #34](https://github.com/campmindshark/spectrum/issues/34).